### PR TITLE
AsyncDatum

### DIFF
--- a/src/AsyncData.spec.ts
+++ b/src/AsyncData.spec.ts
@@ -114,20 +114,15 @@ describe('AsyncData', () => {
 
     test('can be converted to an Optional if there is data', async () => {
       const async = AsyncData.loaded<string>(['test']);
-      expect(async.getOptional().get()).toBe('test');
+      expect(async.getOptional().get()).toEqual(['test']);
     });
 
     test('can be converted to an Optional when a second request has been made', async () => {
       const async = AsyncData.loaded<string>(['test']);
       expect(async.getOptional().isPresent()).toBe(true);
       const reload = async.loadMore();
-      expect(reload.getOptional().get()).toBe('test');
+      expect(reload.getOptional().get()).toEqual(['test']);
       expect;
-    });
-
-    test('can be converted to an Optional array if there is data', async () => {
-      const async = AsyncData.loaded<string>(['test']);
-      expect(async.getAllOptional().get()).toEqual(['test']);
     });
 
     test('can be converted to an empty Optional if there is an error', async () => {
@@ -138,16 +133,16 @@ describe('AsyncData', () => {
 
   describe('.orElse', () => {
     test('returns the internal value as a single value if there is one', () => {
-      expect(AsyncData.loaded([1]).orElse(3)).toEqual(1);
+      expect(AsyncData.loaded([1]).orElse([3])).toEqual([1]);
     });
     test('returns the internal value as an array if there is one', () => {
       expect(AsyncData.loaded([1, 2]).orElse([3, 4])).toEqual([1, 2]);
     });
     test('returns the default value if there is no internal value', () => {
-      expect(AsyncData.loading().orElse(3)).toEqual(3);
+      expect(AsyncData.loading().orElse([3])).toEqual([3]);
     });
     test('returns the internal value if on a second load', () => {
-      expect(AsyncData.loaded([5]).loadMore().orElse(3)).toEqual(5);
+      expect(AsyncData.loaded([5]).loadMore().orElse([3])).toEqual([5]);
     });
     test('returns the default array if there is no internal value', () => {
       expect(AsyncData.loading().orElse([3, 4])).toEqual([3, 4]);
@@ -180,29 +175,6 @@ describe('AsyncData', () => {
     test('throws an error if data load failed', () => {
       const ad = AsyncData.errored(new Error('Testing error'));
       expect(() => ad.value()).toThrowError('Testing error');
-    });
-  });
-
-  describe('.singleValue', () => {
-    test('returns the internal value if successfully loaded', () => {
-      const ad = AsyncData.loaded([1]);
-      expect(ad.singleValue()).toBe(1);
-    });
-
-    test('throws an error if not single-valued', () => {
-      const ad = AsyncData.loaded([1, 2]);
-      expect(() => ad.singleValue()).toThrowError('Data is not single-valued');
-    });
-    test('throws an error if data is not loaded', () => {
-      const ad = AsyncData.loading();
-      expect(() => ad.singleValue()).toThrowError(
-        'Trying to access AsyncData before it has data'
-      );
-    });
-
-    test('throws an error if data load failed', () => {
-      const ad = AsyncData.errored(new Error('Testing error'));
-      expect(() => ad.singleValue()).toThrowError('Testing error');
     });
   });
 

--- a/src/AsyncData.ts
+++ b/src/AsyncData.ts
@@ -1,24 +1,8 @@
 import { AsyncDatum } from "./AsyncDatum.js";
+import { RemoteDataStatus } from "./RemoteDataStatus.js";
 import { Optional } from "./Optional.js";
 
 
-/**
- * The various states that an async request for data can be in
- */
-export enum RemoteDataStatus {
-  /** No request has been sent yet */
-  'NotAsked',
-  /** A request has been sent, but no response has been received */
-  'Loading',
-  /** A response has been received and it indicated an error */
-  'Failed',
-  /** A response has been received and it was successful */
-  'Succeeded',
-  /** @deprecated synonym for `Failed` */
-  'Failure' = RemoteDataStatus.Failed,
-  /** @deprecated synonym for `Succeeded` */
-  'Success' = RemoteDataStatus.Succeeded,
-}
 
 /**
  * This class represents data from a remote source that takes time to load.
@@ -94,7 +78,7 @@ export class AsyncData<D, E = {}> {
    */
   static errored<ED, EE = {}>(error: EE) {
     return new AsyncData<ED, EE>({
-      status: RemoteDataStatus.Failure,
+      status: RemoteDataStatus.Failed,
       error,
     });
   }

--- a/src/AsyncData.ts
+++ b/src/AsyncData.ts
@@ -1,4 +1,4 @@
-import { Either } from "./Either.js";
+import { AsyncDatum } from "./AsyncDatum.js";
 import { Optional } from "./Optional.js";
 
 
@@ -33,7 +33,7 @@ export enum RemoteDataStatus {
  */
 export class AsyncData<D, E = {}> {
   protected status: RemoteDataStatus = RemoteDataStatus.NotAsked;
-  private readonly internal: Either<E, ReadonlyArray<D>>;
+  readonly #internal: AsyncDatum< readonly D[], E>;
 
   private constructor({
     status,
@@ -45,13 +45,12 @@ export class AsyncData<D, E = {}> {
     error?: E;
   }) {
     this.status = status;
-    if (data) {
-      this.internal = Either.right(data);
-    } else if (error) {
-      this.internal = Either.left(error);
-    } else {
-      this.internal = Either.right(Optional.empty());
-    }
+    this.#internal = new AsyncDatum({
+      status,
+      data,
+      error,
+    });
+    
   }
 
   /**
@@ -71,18 +70,6 @@ export class AsyncData<D, E = {}> {
   static loading<LD, LE = {}>() {
     return new AsyncData<LD, LE>({
       status: RemoteDataStatus.Loading,
-    });
-  }
-
-  /**
-   * Create an instance of this type that indicates that a single value has been returned.
-   *
-   * @param data
-   */
-  static loadedSingle<LD, LE = {}>(data: LD) {
-    return new AsyncData<LD, LE>({
-      status: RemoteDataStatus.Succeeded,
-      data: Object.freeze([data]),
     });
   }
 
@@ -124,7 +111,7 @@ export class AsyncData<D, E = {}> {
    * @returns true if this object currently contains retrievable data, i.e. not an error and not an inflight request
    */
   containsData() {
-    return this.internal.isRight();
+    return this.#internal.containsData();
   }
 
   /**
@@ -180,44 +167,27 @@ export class AsyncData<D, E = {}> {
    *
    */
   value(): ReadonlyArray<D> {
-    if (this.containsData()) {
-      return this.internal.getRight();
+    try {
+    return this.#internal.value()
+    } catch (e) {
+      if (this.is(RemoteDataStatus.Failed)) {
+        throw e;
+      }
+      throw new Error("Trying to access AsyncData before it has data",{cause:e});
     }
-    if (this.is(RemoteDataStatus.Failed)) {
-      throw this.internal.getLeft();
-    }
-
-    throw new Error('Trying to access AsyncData before it has data');
-  }
-
-  /**
-   *
-   */
-  singleValue(): D {
-    const val = this.value();
-    if (val.length !== 1) {
-      throw new Error('Data is not single-valued');
-    }
-    return val[0];
   }
 
   loadMore(): AsyncData<D, E> {
     if (this.containsData()) {
       return new AsyncData<D, E>({
         status: RemoteDataStatus.Loading,
-        data: this.internal.getRight(),
+        data: this.#internal.value(),
       });
     }
 
     return AsyncData.loading();
   }
 
-  /**
-   * Get the data as an optional and treat it as a single value
-   */
-  getOptional(): Optional<D> {
-    return this.getAllOptional().map((a) => a[0]);
-  }
 
   /**
    * Get the data as an optional and treat it as an array
@@ -225,15 +195,12 @@ export class AsyncData<D, E = {}> {
    * This will return any internal data that exists. As a result, it will
    * return data after a call to `loadMore`.
    */
-  getAllOptional(): Optional<readonly D[]> {
+  getOptional(): Optional<readonly D[]> {
     return this.containsData()
-      ? Optional.of(this.internal.getRight())
+      ? Optional.of(this.#internal.value())
       : Optional.empty<D[]>();
   }
 
-  private isArray(v: D | readonly D[]): v is readonly D[] {
-    return Array.isArray(v);
-  }
 
   /**
    * Treats the data as an Optional and returns the internal
@@ -241,15 +208,12 @@ export class AsyncData<D, E = {}> {
    *
    * @param v
    */
-  orElse(v: D | readonly D[]): typeof v {
-    if (this.isArray(v)) {
-      return this.getAllOptional().orElse(v);
-    }
+  orElse(v: readonly D[]): typeof v {
     return this.getOptional().orElse(v);
   }
 
   append(v: D[]): AsyncData<D> {
-    const currentData = this.containsData() ? this.internal.getRight() : [];
+    const currentData = this.containsData() ? this.#internal.value() : [];
     return AsyncData.loaded(currentData.concat(v));
   }
 
@@ -259,15 +223,11 @@ export class AsyncData<D, E = {}> {
    */
   private getNonLoadedResult<U>() {
     if (this.status === RemoteDataStatus.NotAsked) {
-      return AsyncData.notAsked<U, E>();
+      return AsyncData.notAsked<U[], E>();
     }
 
     if (this.status === RemoteDataStatus.Loading && !this.containsData()) {
-      return AsyncData.loading<U, E>();
-    }
-
-    if (this.status === RemoteDataStatus.Failure) {
-      return AsyncData.errored<U, E>(this.internal.getLeft());
+      return AsyncData.loading<U[], E>();
     }
   }
 
@@ -276,8 +236,8 @@ export class AsyncData<D, E = {}> {
   ): AsyncData<U, E> {
     return (
       this.getNonLoadedResult() ??
-      this.cloneWithNewData(this.internal.getRight().map(callbackfn))
-    );
+      this.cloneWithNewData(this.#internal.value().map(callbackfn))
+    ) as AsyncData<U, E>;
   }
 
   mapValue<U>(
@@ -291,8 +251,8 @@ export class AsyncData<D, E = {}> {
   ): AsyncData<D, E> {
     return (
       this.getNonLoadedResult() ??
-      this.cloneWithNewData(this.internal.getRight().filter(callbackfn))
-    );
+      this.cloneWithNewData(this.#internal.value().filter(callbackfn))
+    ) as AsyncData<D, E>;
   }
 
   reduce<U>(
@@ -307,9 +267,9 @@ export class AsyncData<D, E = {}> {
     return (
       this.getNonLoadedResult() ??
       this.cloneWithNewData([
-        this.internal.getRight().reduce<U>(callbackfn, initialValue),
+        this.#internal.value().reduce<U>(callbackfn, initialValue),
       ])
-    );
+    ) as AsyncData<U, E>;
   }
 
   find(

--- a/src/AsyncDatum.spec.ts
+++ b/src/AsyncDatum.spec.ts
@@ -1,0 +1,151 @@
+import { expect, describe, test } from 'vitest';
+import { AsyncDatum } from './AsyncDatum.js';
+
+describe('AsyncDatum', () => {
+  test('represents a remotely loaded piece of data', () => {
+    const data = AsyncDatum.loaded([1, 2, 3, 4]);
+    expect(data.value()).toEqual([1, 2, 3, 4]);
+  });
+
+
+
+  describe('.isAsked', () => {
+    test('returns true if a request is in flight', () => {
+      const async = AsyncDatum.loading();
+      expect(async.isAsked()).toBe(true);
+    });
+    test('returns true if a data is loaded', () => {
+      const async = AsyncDatum.loaded<string>('');
+      expect(async.isAsked()).toBe(true);
+    });
+    test('returns true if there is an error', () => {
+      const async = AsyncDatum.errored(new Error('Dummy error'));
+      expect(async.isAsked()).toBe(true);
+    });
+    test('returns false if no request has been sent', () => {
+      const async = AsyncDatum.notAsked();
+      expect(async.isAsked()).toBe(false);
+    });
+  });
+
+  describe('.isLoaded', () => {
+    test('returns false if a request is in flight', () => {
+      const async = AsyncDatum.loading();
+      expect(async.isLoaded()).toBe(false);
+    });
+    test('returns true if a data is loaded', () => {
+      const async = AsyncDatum.loaded<string>('');
+      expect(async.isLoaded()).toBe(true);
+    });
+    
+    test('returns true if there is an error', () => {
+      const async = AsyncDatum.errored(new Error('Dummy error'));
+      expect(async.isLoaded()).toBe(true);
+    });
+    test('returns false if no request has been sent', () => {
+      const async = AsyncDatum.notAsked();
+      expect(async.isLoaded()).toBe(false);
+    });
+  });
+
+  describe('.getOptional', () => {
+    test('can be converted to an empty Optional when no request has been made', async () => {
+      const async = AsyncDatum.notAsked<{}>();
+      expect(async.getOptional().isPresent()).toBe(false);
+    });
+
+    test('can be converted to an empty Optional when a request has been made', async () => {
+      const async = AsyncDatum.loading<{}>();
+      expect(async.getOptional().isPresent()).toBe(false);
+    });
+
+    test('can be converted to an Optional if there is data', async () => {
+      const async = AsyncDatum.loaded<string>('test');
+      expect(async.getOptional().get()).toBe('test');
+    });
+
+    test('can be converted to an Optional array if there is data', async () => {
+      const async = AsyncDatum.loaded<string>('test');
+      expect(async.getOptional().get()).toEqual('test');
+    });
+
+    test('can be converted to an empty Optional if there is an error', async () => {
+      const async = AsyncDatum.errored(new Error('Oh dear'));
+      expect(async.getOptional().isPresent()).toBe(false);
+    });
+  });
+
+  describe('.orElse', () => {
+    test('returns the internal value as a single value if there is one', () => {
+      expect(AsyncDatum.loaded(1).orElse(3)).toEqual(1);
+    });
+    test('returns the internal value as an array if there is one', () => {
+      expect(AsyncDatum.loaded([1, 2]).orElse([3, 4])).toEqual([1, 2]);
+    });
+    test('returns the default value if there is no internal value', () => {
+      expect(AsyncDatum.loading().orElse(3)).toEqual(3);
+    });
+    test('returns the default array if there is no internal value', () => {
+      expect(AsyncDatum.loading().orElse([3, 4])).toEqual([3, 4]);
+    });
+    test('returns the internal array value if on a second load', () => {
+      expect(AsyncDatum.loaded([1, 2]).orElse([3, 4])).toEqual([1, 2]);
+    });
+  });
+
+  describe('.value', () => {
+    test('returns the internal value if successfully loaded', () => {
+      const ad = AsyncDatum.loaded([1]);
+      expect(ad.value()).toEqual([1]);
+    });
+    test('throws an error if data is not loaded', () => {
+      const ad = AsyncDatum.loading();
+      expect(() => ad.value()).toThrowError(
+        'Trying to access AsyncDatum before it has data'
+      );
+    });
+
+    test('throws an error if data load failed', () => {
+      const ad = AsyncDatum.errored(new Error('Testing error'));
+      expect(() => ad.value()).toThrowError('Testing error');
+    });
+  });
+
+  describe('.value', () => {
+    test('returns the internal value if successfully loaded', () => {
+      const ad = AsyncDatum.loaded(1);
+      expect(ad.value()).toBe(1);
+    });
+    test('throws an error if data is not loaded', () => {
+      const ad = AsyncDatum.loading();
+      expect(() => ad.value()).toThrowError(
+        'Trying to access AsyncDatum before it has data'
+      );
+    });
+
+    test('throws an error if data load failed', () => {
+      const ad = AsyncDatum.errored(new Error('Testing error'));
+      expect(() => ad.value()).toThrowError('Testing error');
+    });
+  });
+
+  describe('.containsData', () => {
+    test('returns false for a not asked value', () => {
+      const ad = AsyncDatum.notAsked();
+      expect(ad.containsData()).toBe(false);
+    });
+    test('returns false for an error value', () => {
+      const ad = AsyncDatum.errored(new Error('Dummy'));
+      expect(ad.containsData()).toBe(false);
+    });
+    test('returns false for an initially loading value', () => {
+      const ad = AsyncDatum.loading();
+      expect(ad.containsData()).toBe(false);
+    });
+    test('returns true for a loaded value', () => {
+      const ad = AsyncDatum.loaded('test');
+      expect(ad.containsData()).toBe(true);
+    });
+
+  });
+});

--- a/src/AsyncDatum.ts
+++ b/src/AsyncDatum.ts
@@ -1,0 +1,183 @@
+import { Either } from "./Either.js";
+import { Optional } from "./Optional.js";
+
+
+/**
+ * The various states that an async request for data can be in
+ */
+export enum RemoteDataStatus {
+  /** No request has been sent yet */
+  'NotAsked',
+  /** A request has been sent, but no response has been received */
+  'Loading',
+  /** A response has been received and it indicated an error */
+  'Failed',
+  /** A response has been received and it was successful */
+  'Succeeded',
+  /** @deprecated synonym for `Failed` */
+  'Failure' = RemoteDataStatus.Failed,
+  /** @deprecated synonym for `Succeeded` */
+  'Success' = RemoteDataStatus.Succeeded,
+}
+
+/**
+ * This class represents data from a remote source that takes time to load.
+ * 
+ * This data can be a single value or an array of values. Since there's no way to
+ * infer the shape of the data, the caller is expected to know and to make the
+ * appropriate calls
+ *
+ *
+ * @template D A type representing the shape of data that is being requested
+ * @template E A type representing the shape of errors that can be returned
+ */
+export class AsyncDatum<D, E = {}> {
+  protected status: RemoteDataStatus = RemoteDataStatus.NotAsked;
+  readonly #internal: Either<E, D>;
+
+  constructor({
+    status,
+    data,
+    error,
+  }: {
+    status: RemoteDataStatus;
+    data?: D;
+    error?: E;
+  }) {
+    this.status = status;
+    if (data) {
+      this.#internal = Either.right(data);
+    } else if (error) {
+      this.#internal = Either.left(error);
+    } else {
+      this.#internal = Either.right(Optional.empty());
+    }
+  }
+
+  /**
+   * Create an instance of this type that indicates that the request for async data
+   * has not yet been made
+   */
+  static notAsked<ND, NE = {}>() {
+    return new AsyncDatum<ND, NE>({
+      status: RemoteDataStatus.NotAsked,
+    });
+  }
+
+  /**
+   * Create an instance of this type that indicates that a request is in flight but has not
+   * yet completed
+   */
+  static loading<LD, LE = {}>() {
+    return new AsyncDatum<LD, LE>({
+      status: RemoteDataStatus.Loading,
+    });
+  }
+
+
+  /**
+   * Create an instance of this type that indicates that some data has been returned by the request.
+   *
+   * NB: There is nothing here that asserts that the request is complete. This factory method can
+   * be called multiple times to indicate loading data in progress.
+   *
+   * @param data
+   */
+  static loaded<LD, LE = {}>(data :LD) {
+    return new AsyncDatum<LD, LE>({
+      status: RemoteDataStatus.Succeeded,
+      data: Object.freeze(data),
+    });
+  }
+
+  /**
+   * Create an instance of this type that indicates that the requests has errored.
+   * @param error
+   */
+  static errored<ED, EE = {}>(error: EE) {
+    return new AsyncDatum<ED, EE>({
+      status: RemoteDataStatus.Failure,
+      error,
+    });
+  }
+
+
+  /**
+   * 
+   * @returns true if this object currently contains retrievable data, i.e. not an error and not an inflight request
+   */
+  containsData() {
+    return this.#internal.isRight();
+  }
+
+  /**
+   * Check the status of the data request
+   *
+   * @param status
+   */
+  is(status: RemoteDataStatus) {
+    return this.status === status;
+  }
+
+  /**
+   * Check whether data has been requested
+   */
+  isAsked() {
+    return !this.is(RemoteDataStatus.NotAsked);
+  }
+
+  /**
+   * Check whether data is currently loading
+   */
+  isLoading() {
+    return this.is(RemoteDataStatus.Loading);
+  }
+
+  /**
+   * Check whether any data has loaded (or that the request has failed)
+   */
+  isLoaded() {
+    return this.is(RemoteDataStatus.Succeeded) || this.is(RemoteDataStatus.Failed);
+  }
+
+  /**
+   * Check whether the data errored out
+   */
+  isErrored() {
+    return this.is(RemoteDataStatus.Failed);
+  }
+
+
+  /**
+   *
+   */
+  value(): D {
+    if (this.containsData()) {
+      return this.#internal.getRight();
+    }
+    if (this.is(RemoteDataStatus.Failed)) {
+      throw this.#internal.getLeft();
+    }
+    throw new Error('Trying to access AsyncDatum before it has data');
+  }
+
+
+  /**
+   * Get the data as an optional and treat it as a single value
+   */
+  getOptional(): Optional<D> {
+    return this.containsData() ? Optional.of(this.value()) : Optional.empty();
+  }
+
+  /**
+   * Treats the data as an Optional and returns the internal
+   * value or the provided value.
+   *
+   * @param v
+   */
+  orElse(v: D): typeof v {
+    return this.getOptional().orElse(v);
+  }
+
+  
+}

--- a/src/AsyncDatum.ts
+++ b/src/AsyncDatum.ts
@@ -1,24 +1,6 @@
 import { Either } from "./Either.js";
 import { Optional } from "./Optional.js";
-
-
-/**
- * The various states that an async request for data can be in
- */
-export enum RemoteDataStatus {
-  /** No request has been sent yet */
-  'NotAsked',
-  /** A request has been sent, but no response has been received */
-  'Loading',
-  /** A response has been received and it indicated an error */
-  'Failed',
-  /** A response has been received and it was successful */
-  'Succeeded',
-  /** @deprecated synonym for `Failed` */
-  'Failure' = RemoteDataStatus.Failed,
-  /** @deprecated synonym for `Succeeded` */
-  'Success' = RemoteDataStatus.Succeeded,
-}
+import { RemoteDataStatus } from "./RemoteDataStatus.js";
 
 /**
  * This class represents data from a remote source that takes time to load.
@@ -96,7 +78,7 @@ export class AsyncDatum<D, E = {}> {
    */
   static errored<ED, EE = {}>(error: EE) {
     return new AsyncDatum<ED, EE>({
-      status: RemoteDataStatus.Failure,
+      status: RemoteDataStatus.Failed,
       error,
     });
   }

--- a/src/RemoteDataStatus.ts
+++ b/src/RemoteDataStatus.ts
@@ -1,0 +1,13 @@
+/**
+ * The various states that an async request for data can be in
+ */
+export enum RemoteDataStatus {
+  /** No request has been sent yet */
+  'NotAsked',
+  /** A request has been sent, but no response has been received */
+  'Loading',
+  /** A response has been received and it indicated an error */
+  'Failed',
+  /** A response has been received and it was successful */
+  'Succeeded'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ import { Optional } from './Optional.js';
 
 export * from './Optional.js';
 export * from './AsyncData.js';
+export * from './AsyncDatum.js';
+export * from './RemoteDataStatus.js';
 export * from './Either.js';
 export * from './Lazy.js';
 export * from './partial.js';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,10 +13,10 @@ export default defineConfig({
             all: true,
             thresholds: {
                 autoUpdate: true,
-                lines: 87.04,
-                statements: 86.72,
-                branches: 86.91,
-                functions: 86.11
+                lines: 87.68,
+                statements: 87.27,
+                branches: 87.85,
+                functions: 86.32
             }
         },
     },


### PR DESCRIPTION
This change:
 
 - introduces `AsyncDatum`, which is like `AsyncData`, but for single values
 - makes `AsyncData` exclusively for multi values
 - removes some deprecated enum values

This is a breaking change